### PR TITLE
Fix typos

### DIFF
--- a/src/epub/text/chapter-6.xhtml
+++ b/src/epub/text/chapter-6.xhtml
@@ -51,7 +51,7 @@
 			<p>“In that case we start fresh,” said Humpty Dumpty, “and it’s my turn to choose a subject⁠—” (“He talks about it just as if it was a game!” thought Alice.) “So here’s a question for you. How old did you say you were?”</p>
 			<p>Alice made a short calculation, and said “Seven years and six months.”</p>
 			<p>“Wrong!” Humpty Dumpty exclaimed triumphantly. “You never said a word like it!”</p>
-			<p>“I though you meant ‘How old <em>are</em> you?’ ” Alice explained.</p>
+			<p>“I thought you meant ‘How old <em>are</em> you?’ ” Alice explained.</p>
 			<p>“If I’d meant that, I’d have said it,” said Humpty Dumpty.</p>
 			<p>Alice didn’t want to begin another argument, so she said nothing.</p>
 			<p>“Seven years and six months!” Humpty Dumpty repeated thoughtfully. “An uncomfortable sort of age. Now if you’d asked <em>my</em> advice, I’d have said ‘Leave off at seven’⁠—but it’s too late now.”</p>

--- a/src/epub/text/chapter-8.xhtml
+++ b/src/epub/text/chapter-8.xhtml
@@ -91,7 +91,8 @@
 			</figure>
 			<p>The Knight looked surprised at the question. “What does it matter where my body happens to be?” he said. “My mind goes on working all the same. In fact, the more head downwards I am, the more I keep inventing new things.”</p>
 			<p>“Now the cleverest thing of the sort that I ever did,” he went on after a pause, “was inventing a new pudding during the meat-course.”</p>
-			<p>“In time to have it cooked for the next course?” said Alice. “Well, not the <em>next</em> course,” the Knight said in a slow thoughtful tone: “no, certainly not the next <em>course</em>.”</p>
+			<p>“In time to have it cooked for the next course?” said Alice. “Well, that <em>was</em> quick work, certainly!”</p>
+			<p>“Well, not the <em>next</em> course,” the Knight said in a slow thoughtful tone: “no, certainly not the next <em>course</em>.”</p>
 			<p>“Then it would have to be the next day. I suppose you wouldn’t have two pudding-courses in one dinner?”</p>
 			<p>“Well, not the <em>next</em> day,” the Knight repeated as before: “not the next <em>day</em>. In fact,” he went on, holding his head down, and his voice getting lower and lower, “I don’t believe that pudding ever <em>was</em> cooked! In fact, I don’t believe that pudding ever <em>will</em> be cooked! And yet it was a very clever pudding to invent.”</p>
 			<p>“What did you mean it to be made of?” Alice asked, hoping to cheer him up, for the poor Knight seemed quite low-spirited about it.</p>

--- a/src/epub/text/chapter-9.xhtml
+++ b/src/epub/text/chapter-9.xhtml
@@ -22,7 +22,7 @@
 			<p>“But she said a great deal more than that!” the White Queen moaned, wringing her hands. “Oh, ever so much more than that!”</p>
 			<p>“So you did, you know,” the Red Queen said to Alice. “Always speak the truth⁠—think before you speak⁠—and write it down afterwards.”</p>
 			<p>“I’m sure I didn’t mean⁠—” Alice was beginning, but the Red Queen interrupted her impatiently.</p>
-			<p>“That’s just what I complain of! You <em>should</em> have meant! What do you suppose is the use of child without any meaning? Even a joke should have some meaning⁠—and a child’s more important than a joke, I hope. You couldn’t deny that, even if you tried with both hands.”</p>
+			<p>“That’s just what I complain of! You <em>should</em> have meant! What do you suppose is the use of a child without any meaning? Even a joke should have some meaning⁠—and a child’s more important than a joke, I hope. You couldn’t deny that, even if you tried with both hands.”</p>
 			<p>“I don’t deny things with my <em>hands</em>,” Alice objected.</p>
 			<p>“Nobody said you did,” said the Red Queen. “I said you couldn’t if you tried.”</p>
 			<p>“She’s in that state of mind,” said the White Queen, “that she wants to deny <em>something</em>⁠—only she doesn’t know what to deny!”</p>
@@ -91,7 +91,7 @@
 			<p>The White Queen looked timidly at Alice, who felt she <em>ought</em> to say something kind, but really couldn’t think of anything at the moment.</p>
 			<p>“She never was really well brought up,” the Red Queen went on: “but it’s amazing how good-tempered she is! Pat her on the head, and see how pleased she’ll be!” But this was more than Alice had courage to do.</p>
 			<p>“A little kindness⁠—and putting her hair in papers⁠—would do wonders with her⁠—”</p>
-			<p>The White Queen gave a deep sigh, and laid her head on Alice’s shoulder. “I <em>am</em> so sleepy?” she moaned.</p>
+			<p>The White Queen gave a deep sigh, and laid her head on Alice’s shoulder. “I <em>am</em> so sleepy!” she moaned.</p>
 			<p>“She’s tired, poor thing!” said the Red Queen. “Smooth her hair⁠—lend her your nightcap⁠—and sing her a soothing lullaby.”</p>
 			<p>“I haven’t got a nightcap with me,” said Alice, as she tried to obey the first direction: “and I don’t know any soothing lullabies.”</p>
 			<p>“I must do it myself, then,” said the Red Queen, and she began:</p>


### PR DESCRIPTION
There was an error in chapter 8:

> “In time to have it cooked for the next course?” said Alice. “Well, not the next course,” the Knight said in a slow thoughtful tone: “no, certainly not the next course.”

should be

> "In time to have it cooked for the next course?" said Alice. "Well, that was quick work, certainly!"
"Well, not the next course," the Knight said in a slow thoughtful tone: "no, certainly not the next course." 

https://archive.org/details/ThroughTheLookingGlass_201303/page/n141/mode/1up

Also fixed a few small typos